### PR TITLE
Add a grey line for pure black for separation of lists

### DIFF
--- a/themes/theme-black.css
+++ b/themes/theme-black.css
@@ -176,7 +176,7 @@ html.SHINE.res-nightmode.theme-black.shine-list body {
   background: black !important; }
   html.SHINE.res-nightmode.theme-black.shine-list body > div.content div#siteTable > .thing {
     background: black !important;
-    border-bottom: 1px solid black !important;
+    border-bottom: 1px solid rgb(51,51,51) !important;
     border-left: 5px solid black !important;
     border-top: 0 !important;
     border-right: 0 !important; }


### PR DESCRIPTION
It makes its easier to find the separation when trying to expand for list mode

Before:
![before](https://user-images.githubusercontent.com/1573143/31314629-83bde750-ac37-11e7-8b56-ccf92cdf1c10.PNG)

After:
![after](https://user-images.githubusercontent.com/1573143/31314631-86d4ad8e-ac37-11e7-8d38-f8a500cbb4a7.PNG)
